### PR TITLE
Update Startup.php

### DIFF
--- a/support/Opencart/Startup.php
+++ b/support/Opencart/Startup.php
@@ -135,7 +135,7 @@ class Startup extends \Controller
         $allowed_routes = [];
 
         if (!$allowed_routes = $this->cache->get('opencore_routes')) {
-            $query = $this->db->query("SELECT method, name, uri FROM `opencore_routes` WHERE `status` = '1' ORDER BY uri");
+            $query = $this->db->query("SELECT method, name, uri FROM `" . DB_PREFIX . "opencore_routes` WHERE `status` = '1' ORDER BY uri");
 
             if (!$query->num_rows)
                 return false;


### PR DESCRIPTION
Using it with version Version 3.0.2.0 of OpenCart the tables where created with a prefix. The module installation fails without the prefix